### PR TITLE
Fixing issue tracker URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ you can always send me email (my Github nick at mozilla.com). And I'm
 always happy to accept pull requests!
 
 If you're looking for interesting things to work on, check out the
-**[issue tracker](task.js/issues)**.
+**[issue tracker](https://github.com/mozilla/task.js/issues)**.


### PR DESCRIPTION
Very simple change to get the issue tracker URL to point to the right place; previously this was pointing to https://github.com/mozilla/task.js/blob/master/task.js/issues which yields a 404.
